### PR TITLE
Delegate dependency caching to actions/setup-java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-
-      - name: Cache sbt
-        uses: actions/cache@v3.0.5
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Check that scalafmt has been run
         run: sbt 'all scalafmtSbtCheck scalafmtCheckAll'

--- a/helios/src/test/scala/helios/HeliosSpec.scala
+++ b/helios/src/test/scala/helios/HeliosSpec.scala
@@ -6,7 +6,7 @@ import zio.test.*
 
 object HeliosSpec extends ZIOSpecDefault:
 
-  def spec = suite("HeliosSpec")(
+  def spec: Spec[Any, Throwable] = suite("HeliosSpec")(
     test("decideTargetBrightnessAndMirekValues chooses relax for midnight")(
       for
         _ <- TestSystem.putEnv("TIME_ZONE", "Europe/London")


### PR DESCRIPTION
It has just gained support via
https://github.com/actions/setup-java/pull/302. See also
https://github.com/actions/setup-java#caching-sbt-dependencies.